### PR TITLE
Update runtime to 25.08

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -5,19 +5,19 @@ Date: Sun, 13 Aug 2023 18:31:43 +0200
 Subject: [PATCH 1/3] Update AppStream metadata.
 
 ---
- asc.appdata.xml.in | 21 +++++++++++++++++----
- 1 file changed, 17 insertions(+), 4 deletions(-)
+ asc.appdata.xml.in | 53 +++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 41 insertions(+), 12 deletions(-)
 
 diff --git a/asc.appdata.xml.in b/asc.appdata.xml.in
-index b00f2e2eb..878843868 100644
+index b00f2e2..d755783 100644
 --- a/asc.appdata.xml.in
 +++ b/asc.appdata.xml.in
-@@ -1,7 +1,10 @@
+@@ -1,21 +1,50 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<application>
 -    <id type="desktop">asc.desktop</id>
 -    <licence>CC0</licence>
-+<component type="desktop">
++<component type="desktop-application">
 +    <id>org.asc_hq.ASC</id>
 +    <metadata_license>CC0-1.0</metadata_license>
 +    <project_license>GPL-2.0-or-later</project_license>
@@ -25,30 +25,55 @@ index b00f2e2eb..878843868 100644
 +    <summary>Turn-based strategy game</summary>
      <description>
          <p>
-             Advanced Strategic Command is a free, turn based strategy game. It is designed in the tradition of the Battle Isle series from Bluebyte and is currently available for Windows and Linux.
-@@ -10,12 +13,22 @@
-             ASC can be played both against the AI and against other human players, using hotseat or PlayByMail. It is also used to run the multiplayer universe Project Battle Planets.
+-            Advanced Strategic Command is a free, turn based strategy game. It is designed in the tradition of the Battle Isle series from Bluebyte and is currently available for Windows and Linux.
++            Advanced Strategic Command is a free, turn based strategy game.
++            It is designed in the tradition of the Battle Isle series from
++            Bluebyte and is currently available for Windows and Linux.
+         </p>
+         <p>
+-            ASC can be played both against the AI and against other human players, using hotseat or PlayByMail. It is also used to run the multiplayer universe Project Battle Planets.
++            ASC can be played both against the AI and against other human players,
++            using hotseat or PlayByMail. It is also used to run the multiplayer
++            universe Project Battle Planets.
          </p>
      </description>
+-    <url type="homepage">http://www.asc-hq.org/</url>
 +    <content_rating type="oars-1.1">
 +        <content_attribute id="violence-fantasy">moderate</content_attribute>
 +    </content_rating>
-     <url type="homepage">http://www.asc-hq.org/</url>
++    <url type="homepage">http://www.asc-hq.org</url>
 +    <url type="bugtracker">https://sourceforge.net/p/asc-hq/bugs/</url>
-+    <url type="vcs-browser"> https://github.com/ValHaris/asc-hq/</url>
++    <url type="vcs-browser">https://github.com/ValHaris/asc-hq/</url>
++    <launchable type="desktop-id">org.asc_hq.ASC.desktop</launchable>
++    <developer id="io.github.ValHaris">
++      <name>Martin Bickel</name>
++    </developer>
++    <update_contact>bickel@asc-hq.org</update_contact>
      <screenshots>
-         <screenshot type="default">http://www.asc-hq.org/screenshots/screen05.jpg</screenshot>
-         <screenshot>http://www.asc-hq.org/screenshots/screen06.jpg</screenshot>
-         <screenshot>http://www.asc-hq.org/screenshots/screen07.jpg</screenshot>
-         <screenshot>http://www.asc-hq.org/screenshots/screen08.jpg</screenshot>
+-        <screenshot type="default">http://www.asc-hq.org/screenshots/screen05.jpg</screenshot>
+-        <screenshot>http://www.asc-hq.org/screenshots/screen06.jpg</screenshot>
+-        <screenshot>http://www.asc-hq.org/screenshots/screen07.jpg</screenshot>
+-        <screenshot>http://www.asc-hq.org/screenshots/screen08.jpg</screenshot>
++        <screenshot type="default">
++            <image>http://www.asc-hq.org/screenshots/screen05.jpg</image>
++        </screenshot>
++        <screenshot>
++            <image>http://www.asc-hq.org/screenshots/screen06.jpg</image>
++        </screenshot>
++        <screenshot>
++            <image>http://www.asc-hq.org/screenshots/screen07.jpg</image>
++        </screenshot>
++        <screenshot>
++            <image>http://www.asc-hq.org/screenshots/screen08.jpg</image>
++        </screenshot>
      </screenshots>
+-    <updatecontact>bickel@asc-hq.org</updatecontact>
+-</application>
 +    <releases>
 +        <release version="2.6.1" date="2015-12-06" type="stable"/>
 +        <release version="2.6.0" date="2013-12-28" type="stable"/>
 +        <release version="2.4.0" date="2009-12-21" type="stable"/>
 +    </releases>
-     <updatecontact>bickel@asc-hq.org</updatecontact>
--</application>
 +</component>
 
 From ef532894c8a6e234047bd3fd9a7f8e003cb42960 Mon Sep 17 00:00:00 2001

--- a/org.asc_hq.ASC.yaml
+++ b/org.asc_hq.ASC.yaml
@@ -1,6 +1,6 @@
 id: org.asc_hq.ASC
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: asc-window
 rename-appdata-file: asc.appdata.xml
@@ -11,6 +11,14 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/aclocal
+  - /share/man
+  - '*.a'
+  - '*.la'
 
 modules:
   - shared-modules/lua5.1/lua-5.1.5.json
@@ -20,19 +28,18 @@ modules:
     config-opts:
       - -DPHYSFS_BUILD_TEST=OFF
       - -DPHYSFS_BUILD_STATIC=OFF
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:
       - type: archive
         url: https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2
         sha256: ca862097c0fb451f2cacd286194d071289342c107b6fe69079c079883ff66b69
-
-  - shared-modules/glu/glu-9.json
 
   - shared-modules/SDL/sdl12-compat.json
   - shared-modules/SDL/SDL_mixer-1.2.12.json
   - shared-modules/SDL/SDL_image-1.2.12.json
   - shared-modules/smpeg/smpeg-0.4.5.json
   - name: SDL_sound
-    rm-configure: true,
+    rm-configure: true
     config-opts:
       - --disable-static
     sources:
@@ -41,8 +48,8 @@ modules:
         sha256: 3999fd0bbb485289a52be14b2f68b571cb84e380cc43387eadf778f64c79e6df
       - type: shell
         commands:
-          - cp /usr/share/gnu-config/config.sub .
-          - cp /usr/share/gnu-config/config.guess .
+          - cp /usr/share/automake-*/config.sub .
+          - cp /usr/share/automake-*/config.guess .
       - type: script
         dest-filename: autogen.sh
         commands:
@@ -51,19 +58,12 @@ modules:
   - name: wxWidgets
     cleanup:
       - /bin
-      - /include
-      - /lib/cmake
       - /lib/wx
       - /share
     sources:
       - type: archive
         url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.2.1/wxWidgets-3.2.2.1.tar.bz2
         sha256: dffcb6be71296fff4b7f8840eb1b510178f57aa2eb236b20da41182009242c02
-        x-checker-data:
-          type: anitya
-          project-id: 5150
-          stable-only: true
-          url-template: https://github.com/wxWidgets/wxWidgets/releases/download/v$version/wxWidgets-$version.tar.bz2
 
   - name: boost
     buildsystem: simple
@@ -72,33 +72,23 @@ modules:
       - ./b2 install -j ${FLATPAK_BUILDER_N_JOBS}
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2
+        url: https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.bz2
         sha256: 475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39
-        x-checker-data:
-          type: html
-          url: https://www.boost.org/feed/downloads.rss
-          version-pattern: <link>https://www.boost.org/users/history/version_([\d_]+).html</link>
-          url-template: https://boostorg.jfrog.io/artifactory/main/release/$version0.$version2.$version4/source/boost_$version.tar.bz2
-    cleanup:
-      - /include/boost
-      - /lib/libboost*.a
-      - /lib/cmake
 
   - name: sigc++
     sources:
-      - sha256: 0b68dfc6313c6cc90ac989c6d722a1bf0585ad13846e79746aa87cb265904786
-        type: archive
+      - type: archive
         url: https://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.3.tar.xz
+        sha256: 0b68dfc6313c6cc90ac989c6d722a1bf0585ad13846e79746aa87cb265904786
     config-opts:
       - --disable-documentation
     cleanup:
-      - '*.la'
-      - /include/sigc++-2.0
-      - /lib/pkgconfig
       - /lib/sigc++-2.0
 
   - name: xvid
     subdir: build/generic
+    build-options:
+      cflags: -std=c17
     sources:
       - type: archive
         url: https://downloads.xvid.com/downloads/xvidcore-1.3.7.tar.gz


### PR DESCRIPTION
- Update runtime to 25.08
- Fix appdata paper cuts
- Disable x-checker-data

> There is no point in running them at all when building legacy software.

See: https://github.com/flathub/org.asc_hq.ASC/pull/17#discussion_r2851481800